### PR TITLE
Tweak to compile against latest tooltip package.

### DIFF
--- a/site/examples/tooltip/tooltip.ts
+++ b/site/examples/tooltip/tooltip.ts
@@ -28,9 +28,9 @@ function getCursorTooltips(state: EditorState): readonly Tooltip[] {
         pos: range.head,
         above: true,
         strictSide: true,
-        class: "cm-cursor-tooltip",
         create: () => {
           let dom = document.createElement("div")
+          dom.className = "cm-cursor-tooltip"
           dom.textContent = text
           return {dom}
         }


### PR DESCRIPTION
Setting `class` still works but is deprecated. The field is gone from
the type though, so the example didn't compile for TypeScript clients.