### PR TITLE
Fix `wordHover` example

### DIFF
--- a/site/examples/tooltip/hover.ts
+++ b/site/examples/tooltip/hover.ts
@@ -27,7 +27,7 @@ import {EditorView, EditorState, basicSetup} from "@codemirror/basic-setup"
 
 new EditorView({
   state: EditorState.create({
-    doc: "Hover over words to get tooltips\n",
+    doc: "Hover over words\nto get tooltips",
     extensions: [basicSetup, wordHover]
   }),
   parent: document.querySelector("#hover-editor")!

--- a/site/examples/tooltip/hover.ts
+++ b/site/examples/tooltip/hover.ts
@@ -15,7 +15,7 @@ export const wordHover = hoverTooltip((view, pos, side) => {
     above: true,
     create(view) {
       let dom = document.createElement("div")
-      dom.textContent = text.slice(start, end)
+      dom.textContent = view.state.doc.slice(start, end)
       return {dom}
     }
   }


### PR DESCRIPTION
The `wordHover` example breaks when there are multiple lines in the document. Since `start` and `end` are doc-offsets not line-offsets, slicing the `line` string will be out-of-bounds. The attached patch fixes by slicing the `Text` doc instead.