### PR TITLE
Change id for search box to not conflict with `#search` anchor

### DIFF
--- a/site/docs/ref/ref.js
+++ b/site/docs/ref/ref.js
@@ -2,7 +2,7 @@
   // Search box
 
   let space = document.querySelector("#toc").appendChild(document.createElement("div"))
-  space.id = "search"
+  space.id = "searchbox"
   let box = space.appendChild(document.createElement("input"))
   box.setAttribute("aria-label", "search")
   box.placeholder = "search"

--- a/site/style/site.css
+++ b/site/style/site.css
@@ -140,12 +140,12 @@ nav#toc a.current-section {
   color: black;
 }
 
-#search ul.results {
+#searchbox ul.results {
   font-size: 85%;
   padding-left: 3px;
 }
 
-#search input.active {
+#searchbox input.active {
   border-bottom: 1px solid silver;
 }
 


### PR DESCRIPTION
In documentation, @codemirror/search anchor is `#search` and cannot be
activated because the searchbox is also `#search`.