### PR TITLE
Fix minor problem with changeByRange example

### DIFF
--- a/site/examples/change/index.md
+++ b/site/examples/change/index.md
@@ -56,7 +56,7 @@ would wrap all ranges in underscores, for example:
 ```javascript
 view.dispatch(view.state.changeByRange(range => ({
   changes: [{from: range.from, insert: "_"}, {from: range.to, insert: "_"}],
-  range: EditorSelection.range(range.from + 2, range.to + 2)
+  range: EditorSelection.range(range.from + 1, range.to + 2)
 })))
 ```
 


### PR DESCRIPTION
Fixed a one off error.  As adding one to the `range.from` instead of two prevents the selection from moving backward every time it is run as it did before.