### PR TITLE
Fix logo link

### DIFF
--- a/site/examples/million/million.ts
+++ b/site/examples/million/million.ts
@@ -8,7 +8,7 @@ let lines = [`<!doctype html>`, `<meta charset="utf8">`, `<body>`]
 let repeated = [`  <p>These lines are repeated many times to save memory on`,
                 `  string data.</p>`,
                 `  <hr>`,
-                `  <img src="../logo.svg">`,
+                `  <img src="../../style/logo.svg">`,
                 ``]
 for (let i = 0; lines.length < 2e6; i++) lines.push(repeated[i % repeated.length])
 lines.push(`</body>`, ``)

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
   meta: {"og:title": "CodeMirror",
          "og:type": "website",
          "og:url": "http://codemirror.net/",
-         "og:image": "http://codemirror.net/logo.svg",
+         "og:image": "http://codemirror.net/style/logo.svg",
          "og:description": "In-browser code editor"}
 }>>
 


### PR DESCRIPTION
The logo is on [`/style/logo.svg`](https://codemirror.net/style/logo.svg), not in [`/logo.svg`](https://codemirror.net/logo.svg).
Maybe you want to put it on the root of the site directory?