### PR TITLE
Snippet Extension

### DIFF
--- a/site/docs/community/index.html
+++ b/site/docs/community/index.html
@@ -117,6 +117,11 @@ th { text-align: left }
   <dd><a href="https://yjs.dev/">Yjs</a>-based collaborative editing plugin.</dd>
 </dl>
 
+  <dt><a href="https://github.com/A99US/codemirror-6-snippetbuilder">
+    @A99US/codemirror-6-snippetbuilder
+  </a></dt>
+  <dd>Convert snippets from other app (like <a href="https://github.com/capaj/vscode-standardjs-snippets/blob/master/snippets/javascript.json">this one</a>) to be used in CodeMirror 6.</dd>
+
 <h2 id=wrappers>Wrappers and Framework Integration</h2>
 
 <dl>


### PR DESCRIPTION
This is a function for CodeMirror 6 to convert a standard array of snippet and turn it into snippet array that is ready to use in CodeMirror 6 extension.