### PR TITLE
fix(try): merge example escape newline

### DIFF
--- a/site/try/try.ts
+++ b/site/try/try.ts
@@ -407,7 +407,7 @@ let view = new MergeView({
     extensions: basicSetup
   },
   b: {
-    doc: doc.replace(/t/g, "T") + "\nSix",
+    doc: doc.replace(/t/g, "T") + "\\nSix",
     extensions: [
       basicSetup,
       EditorView.editable.of(false),


### PR DESCRIPTION
### Before
https://codemirror.net/try/?example=Merge+View
![image](https://user-images.githubusercontent.com/10756296/230721847-4d6f7065-cb04-4ecb-a66d-f9de0aa28cf6.png)


### After
![image](https://user-images.githubusercontent.com/10756296/230721953-20753a8a-6a8b-49db-a3e2-e3e42ed848b2.png)
