### PR TITLE
fix: set checked in constructor

### DIFF
--- a/site/examples/decoration/checkbox.ts
+++ b/site/examples/decoration/checkbox.ts
@@ -3,7 +3,7 @@
 import {WidgetType} from "@codemirror/view"
 
 class CheckboxWidget extends WidgetType {
-  constructor(readonly checked: boolean) { super() }
+  constructor(readonly checked: boolean) { super(); this.checked = checked }
 
   eq(other: CheckboxWidget) { return other.checked == this.checked }
 


### PR DESCRIPTION
The checkbox example does not work properly when checked is not set in the constructor.