### PR TITLE
Add link to `codemirror-lang-sparql` community package

### DIFF
--- a/site/docs/community/index.html
+++ b/site/docs/community/index.html
@@ -45,6 +45,7 @@ th { text-align: left }
   <tr><td><a href="https://nixos.org/">Nix</a></td><td><a href="https://github.com/replit/codemirror-lang-nix">@replit/codemirror-lang-nix</a></td></tr>
   <tr><td><a href="https://www.r-project.org/">R</a></td><td><a href="https://github.com/TravisYeah/lang-r">codemirror-lang-r</a></td></tr>
   <tr><td><a href="https://soliditylang.org/">Solidity</a></td><td><a href="https://www.npmjs.com/package/@replit/codemirror-lang-solidity">@replit/codemirror-lang-solidarity</a></td></tr>
+  <tr><td><a href="https://www.w3.org/TR/sparql11-query/">Sparql</a></td><td><a href="https://www.npmjs.com/package/codemirror-lang-sparql">codemirror-lang-sparql</a></td></tr>
   <tr><td><a href="https://svelte.dev/">Svelte</a></td><td><a href="https://github.com/replit/codemirror-lang-svelte">@replit/codemirror-lang-svelte</a></td></tr>
   <tr><td><a href="https://www.w3.org/TR/WGSL/">WGSL</a></td><td><a href="https://github.com/iizukak/codemirror-lang-wgsl">codemirror-lang-wgsl</a></td></tr>
 </table>


### PR DESCRIPTION
**This adds the link to codemirror-lang-sparql** 

Refs:
- github https://github.com/aatauil/codemirror-lang-sparql
- npm https://www.npmjs.com/package/codemirror-lang-sparql

---

Used in the following packages:
- https://github.com/aatauil/sparql-browser-extension
- https://github.com/aatauil/sparql-editor