### PR TITLE
Add link to codemirror-lang-hcl community package

### DIFF
--- a/site/docs/community/index.html
+++ b/site/docs/community/index.html
@@ -38,6 +38,7 @@ th { text-align: left }
   <tr><td><a href="https://graphql.org/">GraphQL</a></td><td><a href="https://www.npmjs.com/package/cm6-graphql">cm6-graphql</a></td></tr>
   <tr><td><a href="https://graphviz.org/">Graphviz</a></td><td><a href="https://github.com/yskszk63/cm-lang-dot">cm-lang-dot</a> or <a href="https://github.com/mdaines/viz-js/">@viz-js/lang-dot</a></td></tr>
   <tr><td><a href="https://handlebarsjs.com/">Handlebars</a></td><td><a href="https://github.com/xiechao/lang-handlebars">@xiechao/codemirror-lang-handlebars</a></td></tr>
+  <tr><td><a href="https://github.com/hashicorp/hcl">HCL</a></td><td><a href="https://github.com/haoqixu/codemirror-lang-hcl">codemirror-lang-hcl</a></td></tr>
   <tr><td><a href="https://en.wikipedia.org/wiki/HTTP">HTTP</a></td><td><a href="https://github.com/glitchedgitz/codemirror-lang-http">codemirror-lang-http</a></td></tr>
   <tr><td><a href="https://jsoftware.com/">J</a></td><td><a href="https://github.com/jared-hughes/codemirror-lang-j">codemirror-lang-j</a></td></tr>
   <tr><td><a href="https://janet-lang.org/">Janet</a></td><td><a href="https://github.com/ianthehenry/codemirror-lang-janet">codemirror-lang-janet</a></td></tr>


### PR DESCRIPTION
This PR adds the link to codemirror-lang-hcl which implements [HCL](https://github.com/hashicorp/hcl) language support for the [CodeMirror](https://codemirror.net/6/) code editor.