### PR TITLE
Fix: correct instruction on how to run code for 'Try CodeMirror' editor

### DIFF
--- a/site/try/index.html
+++ b/site/try/index.html
@@ -142,7 +142,7 @@
 <p><code>@codemirror</code> and <code>@lezer</code> packages can be
 imported directly by name. Other imports should be URLs. You'll
 usually want your script to create an editor
-in <code>document.body</code>. Press Ctrl-Space to run the current
+in <code>document.body</code>. Press Ctrl-Enter to run the current
 code, and see the result (boxed in an <code>&lt;iframe></code>) in the
 “Output” tab. When errors occur or things are logged to the console,
 you can find them in the “Log” tab.</p>


### PR DESCRIPTION
The https://codemirror.net/try/ is awesome but there's a typo in the instruction of how to run code: 

Current (wrong) instruction:
> Press **Ctrl-Space** to run the current code, and see the result (boxed in an <iframe>) in the “Output” tab.

It should be:
> Press **Ctrl-Enter** to run the current code, and see the result (boxed in an <iframe>) in the “Output” tab.

Ctrl-Space is for auto-complete not for running code. The "run" button at top-left is correct `<button id=run title="Run code (Ctrl-Enter)" aria-title="Run code (Ctrl-Enter)">Run</button>`. Therefore, this must be a typo.

Fixing this will make it easier for new users to try out the demo.