### PR TITLE
community: Update BibTeX package name & url in Language Package List

### DIFF
--- a/site/docs/community/index.html
+++ b/site/docs/community/index.html
@@ -32,7 +32,7 @@ th { text-align: left }
 
 <table>
   <tr><th>Language</th><th>Package</th></tr>
-  <tr><td><a href="https://bibtex.org/">BibTeX</a></td><td><a href="https://github.com/citedrive/lang-bibtex">codemirror-lang-bibtex</a></td></tr>
+  <tr><td><a href="https://bibtex.org/">BibTeX</a></td><td><a href="https://www.npmjs.com/package/@citedrive/codemirror-lang-bibtex">@citedrive/codemirror-lang-bibtex</a></td></tr>
   <tr><td><a href="https://clojure.org/">Clojure</a></td><td><a href="https://github.com/nextjournal/clojure-mode">clojure-mode</a></td></tr>
   <tr><td><a href="https://elixir-lang.org">Elixir</a></td><td><a href="https://github.com/livebook-dev/codemirror-lang-elixir">codemirror-lang-elixir</a></td></tr>
   <tr><td><a href="http://golfscript.com/golfscript/">GolfScript</a></td><td><a href="https://github.com/jared-hughes/codemirror-lang-golfscript">codemirror-lang-golfscript</a></td></tr>


### PR DESCRIPTION
The `codemirror-lang-bibtex` package has been published to [npm](https://www.npmjs.com/package/@citedrive/codemirror-lang-bibtex). As part of its publishing, the package has been renamed from `codemirror-lang-bibtex` to `@citedrive/codemirror-lang-bibtex` (as part of npm's organization scoping).